### PR TITLE
Add option to force-install.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ terraform_mirror: https://releases.hashicorp.com/terraform
 
 terraform_install_dir: /usr/local/bin
 
+terraform_force_install: false  # Force-replace /usr/local/bin/terraform with symlink.
+
 terraform_checksums:
   # https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_SHA256SUMS
   '0.11.0':

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,3 +44,4 @@
     src: '{{terraform_binary_dir}}/terraform'
     dest: '{{terraform_install_dir}}/terraform'
     state: link
+    force: '{{terraform_force_install}}'


### PR DESCRIPTION
If terraform has been manually installed in /usr/local/bin, this allows ansible to force-overwrite it with a symlink.