### PR TITLE
Optionally use online checksum

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ terraform_mirror: https://releases.hashicorp.com/terraform
 terraform_install_dir: /usr/local/bin
 
 terraform_force_install: false  # Force-replace /usr/local/bin/terraform with symlink.
+terraform_use_online_checksum: false  # when it's true, requires ansible 2.8+
 
 terraform_checksums:
   # https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_SHA256SUMS

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,5 +2,11 @@
 terraform_name: 'terraform_{{ terraform_ver }}'
 terraform_zip: '{{ terraform_name }}_{{ terraform_platform }}.zip'
 terraform_url: '{{terraform_mirror}}/{{terraform_ver}}/{{ terraform_zip }}'
-terraform_checksum: '{{terraform_checksums[terraform_ver][terraform_platform]}}'
 terraform_binary_dir: '{{terraform_install_dir}}/{{terraform_name}}'
+terraform_checksums_url: '{{ terraform_mirror }}/{{ terraform_ver }}/{{ terraform_name }}_SHA256SUMS'
+terraform_checksum: |-
+  {% if terraform_use_online_checksum %}
+  sha256:{{ terraform_checksums_url }}
+  {% else %}
+  {{terraform_checksums[terraform_ver][terraform_platform]}}
+  {% endif %}


### PR DESCRIPTION
Added a flag **terraform_use_online_checksum** for either using the online checksum file or local checksum dictionary.  
Requires ansible 2.8+, to define it as TRUE.

Local test passed on Ubuntu 18.04 for both the flag is true or false.
