### PR TITLE
Bump Terraform to 0.13.3 (+ 0.13.2)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-terraform_ver: 0.13.2
+terraform_ver: 0.13.3
 terraform_platform: linux_amd64
 terraform_mirror: https://releases.hashicorp.com/terraform
 
@@ -893,7 +893,7 @@ terraform_checksums:
     linux_arm: sha256:5383a0a8dc716fafefc30f08c4c6b73e06c28ba8c2a396fe7ae2d1cb9787c95c
     # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_openbsd_386.zip
     openbsd_386: sha256:45ae994baf3300805727c62f7a898756397efde2388502d87ef7369beeef7821
-    # https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.2_openbsd_amd64.zip
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_openbsd_amd64.zip
     openbsd_amd64: sha256:33637472710a1c2fe77e6fd3047bbd77599764992ab9cff5b7935ecb6ed7f2f5
     # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_solaris_amd64.zip
     solaris_amd64: sha256:2702fd31585c51909ea95a696f49783c40a3921a9a6e8ed703d703836e27dbec
@@ -901,3 +901,29 @@ terraform_checksums:
     windows_386: sha256:043bc61096c51da8b23652e94cb86952f0008ebb30edf86e81965ae09037da04
     # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_windows_amd64.zip
     windows_amd64: sha256:56582718c6694c00e27f6c14ef2684059798961d19e389ab24d9ded0c7d898a1
+  # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_SHA256SUMS
+  '0.13.3':
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_darwin_amd64.zip
+    darwin_amd64: sha256:ccbfd3af8732a47b6bd32c419e1a52e41eb8a39ff7437afffbef438b5c0f92c3
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_freebsd_386.zip
+    freebsd_386: sha256:55d1fd2a709946c1fcfe1152f437843d5e155e9f1fadd85c875fcbe69cb44fd8
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_freebsd_amd64.zip
+    freebsd_amd64: sha256:f4b400a61de88af157ee9955fe226dd4b35474c57bb0e6b8407b395771b86648
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_freebsd_arm.zip
+    freebsd_arm: sha256:86e49667a5d9c476e964d43d7335e50643032a7cbd3dfdc0e262286152221403
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_386.zip
+    linux_386: sha256:5b52a34da61a9b411b519c622078e8e6cc07aa8685e428fe86c4cec51d6dca6f
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip
+    linux_amd64: sha256:35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_arm.zip
+    linux_arm: sha256:c5274bcc6cc597467d9c90ee6f22281496d91da0bc1f899dd185f9c7bedaf207
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_openbsd_386.zip
+    openbsd_386: sha256:9a16d371c9025bef9b6d8ca92260a5623f3ae71c51b967791ea58482686f57a5
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_openbsd_amd64.zip
+    openbsd_amd64: sha256:76e7d480c6979459b4a111d39012def1929ac310b1f84e5756a6209bc8064c2c
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_solaris_amd64.zip
+    solaris_amd64: sha256:4c293e365f34b226d741ac6b7cbed59645b4311618d6e398baef7ef6b896ebd7
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_windows_386.zip
+    windows_386: sha256:f039b0180abff3486022a3e35986aa959b7650a438277b99bfa13a16a11538d0
+    # https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_windows_amd64.zip
+    windows_amd64: sha256:e4aba639b2fb946c5c17b982c22c8ff3a7a3c07725978284ffc1cc651961da2c

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-terraform_ver: 0.13.1
+terraform_ver: 0.13.2
 terraform_platform: linux_amd64
 terraform_mirror: https://releases.hashicorp.com/terraform
 
@@ -875,3 +875,29 @@ terraform_checksums:
     windows_386: sha256:af1babe4ad7aa2e88fbf12e3ee176846db859617c572f3480de59f9284460457
     # https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_windows_amd64.zip
     windows_amd64: sha256:fa7b17147baf4aca478ae83b25c14c1baa064a118a21e0e7b34e3d70e1732b6d
+  # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_SHA256SUMS
+  '0.13.2':
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_darwin_amd64.zip
+    darwin_amd64: sha256:7af2f9c03e8687c87e7798178a2dac9a3061955eb19f0f69501475e017b8d8f6
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_freebsd_386.zip
+    freebsd_386: sha256:62044072f0b73f26c9b3b77d6cf925ac53cc0ecef419d15b3993ee2ed15e98a7
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_freebsd_amd64.zip
+    freebsd_amd64: sha256:e131098931ed49f493c11e1bb1780532efc00af210cd488c247b1213296a1b5b
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_freebsd_arm.zip
+    freebsd_arm: sha256:8d6f4343f3775be50b98f4f70fe6214a291f02c9b2ee9f1453da2519b99a302a
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_386.zip
+    linux_386: sha256:532e761483d68f056e1a038f482dfa7af75fd6a879d5cd33e7c780ca617ea1a8
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_amd64.zip
+    linux_amd64: sha256:6c1c6440c5cb199e85926aea65773450564f501fddcd7876f453ba95b45ba746
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_arm.zip
+    linux_arm: sha256:5383a0a8dc716fafefc30f08c4c6b73e06c28ba8c2a396fe7ae2d1cb9787c95c
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_openbsd_386.zip
+    openbsd_386: sha256:45ae994baf3300805727c62f7a898756397efde2388502d87ef7369beeef7821
+    # https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.2_openbsd_amd64.zip
+    openbsd_amd64: sha256:33637472710a1c2fe77e6fd3047bbd77599764992ab9cff5b7935ecb6ed7f2f5
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_solaris_amd64.zip
+    solaris_amd64: sha256:2702fd31585c51909ea95a696f49783c40a3921a9a6e8ed703d703836e27dbec
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_windows_386.zip
+    windows_386: sha256:043bc61096c51da8b23652e94cb86952f0008ebb30edf86e81965ae09037da04
+    # https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_windows_amd64.zip
+    windows_amd64: sha256:56582718c6694c00e27f6c14ef2684059798961d19e389ab24d9ded0c7d898a1

--- a/dl-checksum.sh
+++ b/dl-checksum.sh
@@ -44,4 +44,4 @@ dl_all () {
     dl $ver $lchecksums windows amd64
 }
 
-dl_all  ${1:-0.13.2}
+dl_all  ${1:-0.13.3}

--- a/dl-checksum.sh
+++ b/dl-checksum.sh
@@ -44,4 +44,4 @@ dl_all () {
     dl $ver $lchecksums windows amd64
 }
 
-dl_all  ${1:-0.13.1}
+dl_all  ${1:-0.13.2}


### PR DESCRIPTION
Allows this role to install Terraform v0.13.2 and v0.13.3.